### PR TITLE
Upgrade to 2.3.0 and change UID length

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --update add \
     --update-cache \
     --repository http://mirror.leaseweb.com/alpine/edge/community/
 
-ENV TSDB_VERSION 2.3.0RC2
+ENV TSDB_VERSION 2.3.0
 ENV HBASE_VERSION 1.2.1
 ENV JAVA_HOME /usr/lib/jvm/java-1.7-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.7-openjdk/bin/

--- a/docker/opentsdb.conf
+++ b/docker/opentsdb.conf
@@ -6,3 +6,12 @@ tsd.storage.enable_compaction = false
 tsd.storage.fix_duplicates = true
 tsd.http.request.enable_chunked = true
 tsd.http.request.max_chunk = 1000000
+
+# The width, in bytes, of metric UIDs, default 3
+tsd.storage.uid.width.metric = 6
+
+# The width, in bytes, of tag name UIDs, default 3
+tsd.storage.uid.width.tagk = 6
+
+# The width, in bytes, of tag value UIDs, default 3
+tsd.storage.uid.width.tagv = 6


### PR DESCRIPTION
To sync with production

Once this is done, you have to remove all data from previous build as the UID length is different and it cannot be mixed up.